### PR TITLE
Typo on systemd service units file

### DIFF
--- a/forking-daemon.service
+++ b/forking-daemon.service
@@ -12,4 +12,4 @@ ExecStart=/usr/bin/daemon \
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
-WantedBy=multiuser.agent
+WantedBy=multi-user.target

--- a/simple-daemon.service
+++ b/simple-daemon.service
@@ -10,4 +10,4 @@ User=root
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
-WantedBy=multiuser.agent
+WantedBy=multi-user.target


### PR DESCRIPTION
-Bug
 the following commands
 ```
 systemctl enable simple-daemon.service
 systemctl enable forking-daemon.service
```
generate the following error message
  "Failed to execute operation: Invalid argument"

-Actions
 corrected typo on WantedBy from multiuser.agent to multi-user.target in both service files

-Fixes
 this allows the following command to work properly
```
  systemctl enable simple-daemon.service
  systemctl enable forking-daemon.service
```